### PR TITLE
Application of boost-aarch64-flags.patch to fix gcc builds on 64 bit …

### DIFF
--- a/tools/build/src/tools/gcc.jam
+++ b/tools/build/src/tools/gcc.jam
@@ -457,10 +457,6 @@ rule setup-address-model ( targets * : sources * : properties * )
                 {
                     option = -m32 ;
                 }
-                else if $(model) = 64
-                {
-                    option = -m64 ;
-                }
             }
             # For darwin, the model can be 32_64. darwin.jam will handle that
             # on its own.


### PR DESCRIPTION
…architecture
# Index: boost_1_58_0/tools/build/src/tools/gcc.jam

--- boost_1_58_0.orig/tools/build/src/tools/gcc.jam
+++ boost_1_58_0/tools/build/src/tools/gcc.jam
@@ -457,10 +457,6 @@ rule setup-address-model ( targets \* : s
                 {
                     option = -m32 ;
                 }
-                else if $(model) = 64
-                {
-                    option = -m64 ;
-                }
           }
           # For darwin, the model can be 32_64. darwin.jam will handle that
           # on its own.
